### PR TITLE
When running in a Wildfly Swarm project, the tccl hasn't necessarily

### DIFF
--- a/pinject-extension/src/main/java/org/soulwing/cdi/properties/converters/InternetAddressPropertyConverter.java
+++ b/pinject-extension/src/main/java/org/soulwing/cdi/properties/converters/InternetAddressPropertyConverter.java
@@ -35,7 +35,7 @@ public class InternetAddressPropertyConverter
   protected boolean checkAvailability() {
     ClassLoader classLoader = (Thread.currentThread().getContextClassLoader() != null) ?
         Thread.currentThread().getContextClassLoader() :
-        InternetAddressPropertyConverter.class.getClassLoader();
+        getClass().getClassLoader();
     try {
       classLoader.loadClass("javax.mail.internet.InternetAddress");
       return true;

--- a/pinject-extension/src/main/java/org/soulwing/cdi/properties/converters/InternetAddressPropertyConverter.java
+++ b/pinject-extension/src/main/java/org/soulwing/cdi/properties/converters/InternetAddressPropertyConverter.java
@@ -33,9 +33,11 @@ public class InternetAddressPropertyConverter
     extends OptionalPropertyConverter {
 
   protected boolean checkAvailability() {
+    ClassLoader classLoader = (Thread.currentThread().getContextClassLoader() != null) ?
+        Thread.currentThread().getContextClassLoader() :
+        InternetAddressPropertyConverter.class.getClassLoader();
     try {
-      Thread.currentThread().getContextClassLoader().loadClass(
-          "javax.mail.internet.InternetAddress");
+      classLoader.loadClass("javax.mail.internet.InternetAddress");
       return true;
     }
     catch (ClassNotFoundException ex) {

--- a/pinject-extension/src/main/java/org/soulwing/cdi/properties/converters/ScheduleExpressionPropertyConverter.java
+++ b/pinject-extension/src/main/java/org/soulwing/cdi/properties/converters/ScheduleExpressionPropertyConverter.java
@@ -36,8 +36,10 @@ public class ScheduleExpressionPropertyConverter extends OptionalPropertyConvert
   @Override
   protected boolean checkAvailability() {
     try {
-      Thread.currentThread().getContextClassLoader().loadClass(
-          "javax.ejb.ScheduleExpression");
+      ClassLoader classLoader = (Thread.currentThread().getContextClassLoader() != null) ?
+          Thread.currentThread().getContextClassLoader() :
+          ScheduleExpressionPropertyConverter.class.getClassLoader();
+      classLoader.loadClass("javax.ejb.ScheduleExpression");
       return true;
     }
     catch (ClassNotFoundException ex) {

--- a/pinject-extension/src/main/java/org/soulwing/cdi/properties/converters/ScheduleExpressionPropertyConverter.java
+++ b/pinject-extension/src/main/java/org/soulwing/cdi/properties/converters/ScheduleExpressionPropertyConverter.java
@@ -38,7 +38,7 @@ public class ScheduleExpressionPropertyConverter extends OptionalPropertyConvert
     try {
       ClassLoader classLoader = (Thread.currentThread().getContextClassLoader() != null) ?
           Thread.currentThread().getContextClassLoader() :
-          ScheduleExpressionPropertyConverter.class.getClassLoader();
+          getClass().getClassLoader();
       classLoader.loadClass("javax.ejb.ScheduleExpression");
       return true;
     }

--- a/pinject-extension/src/main/java/org/soulwing/cdi/properties/converters/UrlPropertyConverter.java
+++ b/pinject-extension/src/main/java/org/soulwing/cdi/properties/converters/UrlPropertyConverter.java
@@ -45,8 +45,11 @@ public class UrlPropertyConverter extends AbstractPropertyConverter {
       while (value.startsWith("/")) {
         value = value.substring(1);
       }
-      URL url = Thread.currentThread().getContextClassLoader()
-          .getResource(value);
+
+      ClassLoader classLoader = (Thread.currentThread().getContextClassLoader() != null) ?
+          Thread.currentThread().getContextClassLoader() :
+          UrlPropertyConverter.class.getClassLoader();
+      URL url = classLoader.getResource(value);
       if (url == null) {
         throw new IllegalArgumentException(
             "no such resource on classpath: " + value);

--- a/pinject-extension/src/main/java/org/soulwing/cdi/properties/converters/UrlPropertyConverter.java
+++ b/pinject-extension/src/main/java/org/soulwing/cdi/properties/converters/UrlPropertyConverter.java
@@ -48,7 +48,7 @@ public class UrlPropertyConverter extends AbstractPropertyConverter {
 
       ClassLoader classLoader = (Thread.currentThread().getContextClassLoader() != null) ?
           Thread.currentThread().getContextClassLoader() :
-          UrlPropertyConverter.class.getClassLoader();
+          getClass().getClassLoader();
       URL url = classLoader.getResource(value);
       if (url == null) {
         throw new IllegalArgumentException(

--- a/pinject-extension/src/main/java/org/soulwing/cdi/properties/resolvers/ClassPathBeanPropertiesResolver.java
+++ b/pinject-extension/src/main/java/org/soulwing/cdi/properties/resolvers/ClassPathBeanPropertiesResolver.java
@@ -54,8 +54,11 @@ public class ClassPathBeanPropertiesResolver
      */
     @Override
     public PropertiesSet load(PropertyRef ref) throws IOException {
-      Enumeration<URL> locations = Thread.currentThread()
-          .getContextClassLoader().getResources(
+      ClassLoader classLoader = (Thread.currentThread().getContextClassLoader() != null) ?
+          Thread.currentThread().getContextClassLoader() :
+          ClassPathBeanPropertiesResolver.class.getClassLoader();
+
+      Enumeration<URL> locations = classLoader.getResources(
               ref.getPath(BeansProperties.NAME));
       PropertiesSet propertiesSet = new PropertiesSet();
       propertiesSet.load(locations);

--- a/pinject-extension/src/main/java/org/soulwing/cdi/properties/resolvers/ClassPathBeanPropertiesResolver.java
+++ b/pinject-extension/src/main/java/org/soulwing/cdi/properties/resolvers/ClassPathBeanPropertiesResolver.java
@@ -56,7 +56,7 @@ public class ClassPathBeanPropertiesResolver
     public PropertiesSet load(PropertyRef ref) throws IOException {
       ClassLoader classLoader = (Thread.currentThread().getContextClassLoader() != null) ?
           Thread.currentThread().getContextClassLoader() :
-          ClassPathBeanPropertiesResolver.class.getClassLoader();
+          getClass().getClassLoader();
 
       Enumeration<URL> locations = classLoader.getResources(
               ref.getPath(BeansProperties.NAME));

--- a/pinject-extension/src/main/java/org/soulwing/cdi/properties/resolvers/MetaInfBeanPropertiesResolver.java
+++ b/pinject-extension/src/main/java/org/soulwing/cdi/properties/resolvers/MetaInfBeanPropertiesResolver.java
@@ -45,7 +45,7 @@ public class MetaInfBeanPropertiesResolver implements PropertyResolver {
   public void init() throws IOException {
     ClassLoader classLoader = (Thread.currentThread().getContextClassLoader() != null) ?
         Thread.currentThread().getContextClassLoader() :
-        MetaInfBeanPropertiesResolver.class.getClassLoader();
+        getClass().getClassLoader();
 
     propertiesSet.load(classLoader.getResources(META_INF_BEANS_PROPERTIES));
   }

--- a/pinject-extension/src/main/java/org/soulwing/cdi/properties/resolvers/MetaInfBeanPropertiesResolver.java
+++ b/pinject-extension/src/main/java/org/soulwing/cdi/properties/resolvers/MetaInfBeanPropertiesResolver.java
@@ -43,8 +43,11 @@ public class MetaInfBeanPropertiesResolver implements PropertyResolver {
    */
   @Override
   public void init() throws IOException {
-    propertiesSet.load(Thread.currentThread().getContextClassLoader()
-        .getResources(META_INF_BEANS_PROPERTIES));
+    ClassLoader classLoader = (Thread.currentThread().getContextClassLoader() != null) ?
+        Thread.currentThread().getContextClassLoader() :
+        MetaInfBeanPropertiesResolver.class.getClassLoader();
+
+    propertiesSet.load(classLoader.getResources(META_INF_BEANS_PROPERTIES));
   }
 
   @Override


### PR DESCRIPTION
initialized yet. So, falling back to the class' classloader prevents
an NPE from occurring and allows the code to continue.

Quote from a Wildfly Swarm developer (from IRC chats):

The TCCL isn't guaranteed to be set. It's usually best to check for
the TCCL and if null return the class loader of the current class.
