### PR TITLE
Fix property cache key collision for constructor injection points

### DIFF
--- a/pinject-extension/src/main/java/org/soulwing/cdi/properties/extension/PropertyInjectionExtension.java
+++ b/pinject-extension/src/main/java/org/soulwing/cdi/properties/extension/PropertyInjectionExtension.java
@@ -18,13 +18,13 @@
  */
 package org.soulwing.cdi.properties.extension;
 
-import java.lang.reflect.Member;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.enterprise.event.Observes;
 import javax.enterprise.inject.spi.AfterBeanDiscovery;
+import javax.enterprise.inject.spi.Annotated;
 import javax.enterprise.inject.spi.BeforeBeanDiscovery;
 import javax.enterprise.inject.spi.BeforeShutdown;
 import javax.enterprise.inject.spi.Extension;
@@ -45,7 +45,7 @@ public class PropertyInjectionExtension implements Extension {
   private static final Logger logger = Logger.getLogger(
       PropertyInjectionExtension.class.getName());
   
-  private final Map<Member, InjectionPoint> wrapperMap = 
+  private final Map<Annotated, InjectionPoint> wrapperMap =
       new ConcurrentHashMap<>();
   
   private final PropertyBeanContainer container;
@@ -109,15 +109,16 @@ public class PropertyInjectionExtension implements Extension {
         logger.finest("injecting into " + injectionPoint);
       }
 
-      InjectionPoint wrapper = wrapperMap.get(injectionPoint.getMember());
+      Annotated annotated = injectionPoint.getAnnotated();
+      InjectionPoint wrapper = wrapperMap.get(annotated);
       if (wrapper == null) {
         wrapper = container.add(injectionPoint, qualifier);
-        wrapperMap.put(injectionPoint.getMember(), wrapper);
+        wrapperMap.put(annotated, wrapper);
       }
       else {
         if (logger.isLoggable(Level.FINE)) {
-          logger.fine("found cached injection point wrapper for member "
-              + injectionPoint.getMember());
+          logger.fine("found cached injection point wrapper for "
+              + annotated);
         }
       }
       event.setInjectionPoint(wrapper);

--- a/pinject-extension/src/test/java/org/soulwing/cdi/properties/extension/ConstructorInjectionTargetBean.java
+++ b/pinject-extension/src/test/java/org/soulwing/cdi/properties/extension/ConstructorInjectionTargetBean.java
@@ -1,0 +1,47 @@
+/*
+ * File created on Aug 11, 2026
+ *
+ * Copyright (c) 2026 Carl Harris, Jr.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.soulwing.cdi.properties.extension;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.soulwing.cdi.properties.Property;
+
+/**
+ * A bean that is used to test injection of multiple distinct properties
+ * into a single constructor.
+ *
+ * @author Carl Harris
+ */
+@SuppressWarnings("CdiInjectionPointsInspection")
+@Dependent
+class ConstructorInjectionTargetBean {
+
+  public final String firstProperty;
+  public final String secondProperty;
+
+  @Inject
+  ConstructorInjectionTargetBean(
+      @Property(name = "constructorFirstProperty") String firstProperty,
+      @Property(name = "constructorSecondProperty") String secondProperty) {
+    this.firstProperty = firstProperty;
+    this.secondProperty = secondProperty;
+  }
+
+}

--- a/pinject-extension/src/test/java/org/soulwing/cdi/properties/extension/ConstructorInjectionTargetBean.java
+++ b/pinject-extension/src/test/java/org/soulwing/cdi/properties/extension/ConstructorInjectionTargetBean.java
@@ -1,7 +1,7 @@
 /*
  * File created on Aug 11, 2026
  *
- * Copyright (c) 2026 Carl Harris, Jr.
+ * Copyright (c) 2026 Sangeetha Muppidi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import org.soulwing.cdi.properties.Property;
  * A bean that is used to test injection of multiple distinct properties
  * into a single constructor.
  *
- * @author Carl Harris
+ * @author Sangeetha Muppidi
  */
 @SuppressWarnings("CdiInjectionPointsInspection")
 @Dependent

--- a/pinject-extension/src/test/java/org/soulwing/cdi/properties/extension/PropertyInjectionExtensionTest.java
+++ b/pinject-extension/src/test/java/org/soulwing/cdi/properties/extension/PropertyInjectionExtensionTest.java
@@ -69,4 +69,13 @@ public class PropertyInjectionExtensionTest {
     System.out.println(bean.path);
   }
 
+  @Test
+  public void testConstructorInject() throws Exception {
+    ConstructorInjectionTargetBean bean =
+        container.instance().select(ConstructorInjectionTargetBean.class).get();
+    assertThat(bean, is(not(nullValue())));
+    assertThat(bean.firstProperty, is(equalTo("first value")));
+    assertThat(bean.secondProperty, is(equalTo("second value")));
+  }
+
 }

--- a/pinject-extension/src/test/resources/META-INF/beans.properties
+++ b/pinject-extension/src/test/resources/META-INF/beans.properties
@@ -2,3 +2,6 @@ myProperty = some value
 org.soulwing.cdi.properties.extension.FieldInjectionTargetBean.stringProperty=#{p:required('myProperty')}
 org.soulwing.cdi.properties.extension.FieldInjectionTargetBean.anotherStringProperty=referenced #{p:required('myProperty')}
 org.soulwing.cdi.properties.extension.FieldInjectionTargetBean.intProperty=99
+
+constructorFirstProperty=first value
+constructorSecondProperty=second value


### PR DESCRIPTION
Cache wrapped injection points by Annotated instead of Member — multiple @Property constructor parameters share the same Member (the constructor), causing the second property to silently resolve to the first's value.
